### PR TITLE
Ignores: apply before listing files

### DIFF
--- a/src/finder/index.ts
+++ b/src/finder/index.ts
@@ -1,27 +1,38 @@
 import fs from 'fs';
+import { doesNotContainIgnores, getDefaultIgnores } from '../ignores';
 
 const isDirectory = (path: string): boolean => fs.statSync(path).isDirectory();
 
-export const listFiles = (folderPath: string) : string[] => {
+export const listFiles = (
+  folderPath: string,
+  ignores: string[],
+) : string[] => {
   const allFiles: string[] = [];
   const files = fs.readdirSync(folderPath);
 
-  files.forEach((file) => {
-    const fullPath = `${folderPath}/${file}`;
-    if (isDirectory(fullPath)) {
-      allFiles.push(...listFiles(fullPath));
-    } else {
-      allFiles.push(fullPath);
-    }
-  });
+  files
+    .filter((file) => doesNotContainIgnores(file, ignores))
+    .forEach((file) => {
+      const fullPath = `${folderPath}/${file}`;
+      if (isDirectory(fullPath)) {
+        allFiles.push(...listFiles(fullPath, ignores));
+      } else {
+        allFiles.push(fullPath);
+      }
+    });
 
   return allFiles;
 };
 
-export const listFilesinFolders = (folders: string[]): string[] => {
+export const listFilesinFolders = (
+  folders: string[],
+  ignores: string[] = getDefaultIgnores(),
+): string[] => {
   const files: string[] = [];
 
-  folders.forEach((folder) => files.push(...listFiles(folder)));
+  folders
+    .forEach((folder) => files
+      .push(...listFiles(folder, ignores)));
 
   return files;
 };

--- a/src/ignores/index.ts
+++ b/src/ignores/index.ts
@@ -6,6 +6,19 @@ const DEFAULT_IGNORES = [
 
 export const getDefaultIgnores = (): string[] => DEFAULT_IGNORES;
 
+export const doesNotContainIgnores = (
+  path: string,
+  ignores: string[] = getDefaultIgnores(),
+) : boolean => {
+  let isAllowed = true;
+  ignores.forEach((ignore) => {
+    if (path.includes(ignore)) {
+      isAllowed = false;
+    }
+  });
+  return isAllowed;
+};
+
 export default {
   getDefaultIgnores,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { getDefaultIgnores } from './ignores';
 
 export const check = (extensions: string[], folders: string[]): string[] => {
   const ignores = getDefaultIgnores();
-  const files = finder.listFilesinFolders(folders);
+  const files = finder.listFilesinFolders(folders, ignores);
 
   return filterByExtensions(files, extensions, ignores);
 };

--- a/tests/unit/finder.test.ts
+++ b/tests/unit/finder.test.ts
@@ -1,4 +1,5 @@
 import finder from '../../src/finder';
+import { getDefaultIgnores } from '../../src/ignores';
 
 describe('Finder tests', () => {
   test('Lists subfolders & files in a folder', () => {
@@ -35,5 +36,15 @@ describe('Finder tests', () => {
     const result = finder.listFilesinFolders(folders);
 
     expect(result).toEqual(expected);
+  });
+
+  test('Does not list ignored folders', () => {
+    // Scanning top level could result in node_modules etc loops.
+    const results = finder.listFilesinFolders(['.']);
+
+    // Assert ignores were not scanned in the first place.
+    results.forEach((result) => {
+      getDefaultIgnores().forEach((ignore) => expect(result.includes(ignore)).toBeFalsy());
+    });
   });
 });


### PR DESCRIPTION
Previously filtered ignores only after files had been listed. That is somewhat inefficient, as it might mean looping through all node_modules before actually filtering out node_modules.

Check ignores as files are listed, so code never enters node_modules & other ignored folders.